### PR TITLE
Add extended length APDU support

### DIFF
--- a/WSCT Unit Tests/ISO7816/CommandAPDUUnitTest.cs
+++ b/WSCT Unit Tests/ISO7816/CommandAPDUUnitTest.cs
@@ -1,3 +1,6 @@
+using System.IO;
+using System.Text;
+using System.Xml.Serialization;
 using NUnit.Framework;
 using WSCT.ISO7816;
 
@@ -6,33 +9,44 @@ namespace WSCT_Unit_Tests.ISO7816
     [TestFixture]
     public class CommandCaseUnitTest
     {
+        private const string XmlHeader = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
+        
         // Case 1
         private const string Case1Apdu = "00A4 0400";
         private static readonly byte[] Case1ApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00 };
+        private static readonly string Case1Xml = $"{XmlHeader}<commandAPDU cla=\"00\" ins=\"A4\" p1=\"04\" p2=\"00\" />";
 
         // Case 2
         private const string Case2Apdu = "00A4 0400 F0";
         private static readonly byte[] Case2ApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0xF0 };
-        
+        private static readonly string Case2Xml = $"{XmlHeader}<commandAPDU cla=\"00\" ins=\"A4\" p1=\"04\" p2=\"00\" le=\"F0\" />";
+
         // Case 3
         private const string Case3Apdu = "00A4 0400 04 0A0B0C0D";
         private static readonly byte[] Case3ApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x04, 0x0A, 0x0B, 0x0C, 0x0D };
+        private static readonly string Case3Xml = $"{XmlHeader}<commandAPDU cla=\"00\" ins=\"A4\" p1=\"04\" p2=\"00\">0A 0B 0C 0D</commandAPDU>";
 
         // Case 4
         private const string Case4Apdu = "00A4 0400 04 0A0B0C0D F0";
         private static readonly byte[] Case4ApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x04, 0x0A, 0x0B, 0x0C, 0x0D, 0xF0 };
+        private static readonly string Case4Xml = $"{XmlHeader}<commandAPDU cla=\"00\" ins=\"A4\" p1=\"04\" p2=\"00\" le=\"F0\">0A 0B 0C 0D</commandAPDU>";
 
         // Case 2E
         private const string Case2EApdu = "00A4 0400 00F00D";
         private static readonly byte[] Case2EApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x00, 0xF0, 0x0D };
-        
+        private static readonly string Case2EXml = $"{XmlHeader}<commandAPDU extended=\"true\" cla=\"00\" ins=\"A4\" p1=\"04\" p2=\"00\" le=\"F00D\" />";
+
         // Case 3E
         private const string Case3EApdu = "00A4 0400 000004 0A0B0C0D";
         private static readonly byte[] Case3EApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x00, 0x00, 0x04, 0x0A, 0x0B, 0x0C, 0x0D };
-        
+        private static readonly string Case3EXml = $"{XmlHeader}<commandAPDU extended=\"true\" cla=\"00\" ins=\"A4\" p1=\"04\" p2=\"00\">0A 0B 0C 0D</commandAPDU>";
+
         // Case 4E
         private const string Case4EApdu = "00A4 0400 000004 0A0B0C0D F00D";
         private static readonly byte[] Case4EApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x00, 0x00, 0x04, 0x0A, 0x0B, 0x0C, 0x0D, 0xF0, 0x0D };
+        private static readonly string Case4EXml = $"{XmlHeader}<commandAPDU extended=\"true\" cla=\"00\" ins=\"A4\" p1=\"04\" p2=\"00\" le=\"F00D\">0A 0B 0C 0D</commandAPDU>";
+        
+        private static readonly XmlSerializer XmlSerializer = new XmlSerializer(typeof(CommandAPDU));
 
         [Test(Description = "Case 1 C-APDU")]
         public void TestCase1ConstructorAndEncode()
@@ -47,11 +61,27 @@ namespace WSCT_Unit_Tests.ISO7816
             Assert.IsFalse(commandApdu.IsCc2E);
             Assert.IsFalse(commandApdu.IsCc3E);
             Assert.IsFalse(commandApdu.IsCc4E);
+            Assert.IsFalse(commandApdu.IsExtended);
             
             // Test encoding
             Assert.AreEqual(Case1ApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x00, commandApdu.Ne);
             Assert.AreEqual(0x00, commandApdu.Nc);
+            
+            // Test XML serialization
+            var memoryStream = new MemoryStream();
+            TextWriter writer = new StreamWriter(memoryStream);
+            XmlSerializer.Serialize(writer, commandApdu);
+            writer.Flush();
+            var outputXml = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.AreEqual(Case1Xml, outputXml);
+            
+            // Test XML deserialization
+            using (TextReader textReader = new StringReader(outputXml))
+            {
+                var unserializedApdu = (CommandAPDU)XmlSerializer.Deserialize(textReader);
+                Assert.AreEqual(commandApdu, unserializedApdu);
+            }            
         }
         
         [Test(Description = "Case 2 C-APDU")]
@@ -67,12 +97,29 @@ namespace WSCT_Unit_Tests.ISO7816
             Assert.IsFalse(commandApdu.IsCc2E);
             Assert.IsFalse(commandApdu.IsCc3E);
             Assert.IsFalse(commandApdu.IsCc4E);
+            Assert.IsFalse(commandApdu.IsExtended);
+
             
             // Test encoding
             Assert.AreEqual(Case2ApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x01, commandApdu.Ne);
             Assert.AreEqual(0x00, commandApdu.Nc);
             
+            // Test XML serialization
+            var memoryStream = new MemoryStream();
+            TextWriter writer = new StreamWriter(memoryStream);
+            XmlSerializer.Serialize(writer, commandApdu);
+            writer.Flush();
+            var outputXml = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.AreEqual(Case2Xml, outputXml);
+            
+            // Test XML deserialization
+            using (TextReader textReader = new StringReader(outputXml))
+            {
+                var unserializedApdu = (CommandAPDU)XmlSerializer.Deserialize(textReader);
+                Assert.AreEqual(commandApdu, unserializedApdu);
+            }     
+
             // Test automatic conversion to extended
             commandApdu.Lc = 0xF00D;
             Assert.AreEqual(CommandCase.CC2E, commandApdu.CommandCase);
@@ -94,11 +141,27 @@ namespace WSCT_Unit_Tests.ISO7816
             Assert.IsTrue(commandApdu.IsCc2E);
             Assert.IsFalse(commandApdu.IsCc3E);
             Assert.IsFalse(commandApdu.IsCc4E);
+            Assert.IsTrue(commandApdu.IsExtended);
             
             // Test encoding
             Assert.AreEqual(Case2EApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x03, commandApdu.Ne);
             Assert.AreEqual(0x00, commandApdu.Nc);
+            
+            // Test XML serialization
+            var memoryStream = new MemoryStream();
+            TextWriter writer = new StreamWriter(memoryStream);
+            XmlSerializer.Serialize(writer, commandApdu);
+            writer.Flush();
+            var outputXml = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.AreEqual(Case2EXml, outputXml);
+            
+            // Test XML deserialization
+            using (TextReader textReader = new StringReader(outputXml))
+            {
+                var unserializedApdu = (CommandAPDU)XmlSerializer.Deserialize(textReader);
+                Assert.AreEqual(commandApdu, unserializedApdu);
+            }   
         }
         
         [Test(Description = "Case 3 C-APDU")]
@@ -114,11 +177,27 @@ namespace WSCT_Unit_Tests.ISO7816
             Assert.IsFalse(commandApdu.IsCc2E);
             Assert.IsFalse(commandApdu.IsCc3E);
             Assert.IsFalse(commandApdu.IsCc4E);
-            
+            Assert.IsFalse(commandApdu.IsExtended);
+
             // Test encoding
             Assert.AreEqual(Case3ApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x00, commandApdu.Ne);
             Assert.AreEqual(0x01, commandApdu.Nc);
+            
+            // Test XML serialization
+            var memoryStream = new MemoryStream();
+            TextWriter writer = new StreamWriter(memoryStream);
+            XmlSerializer.Serialize(writer, commandApdu);
+            writer.Flush();
+            var outputXml = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.AreEqual(Case3Xml, outputXml);
+            
+            // Test XML deserialization
+            using (TextReader textReader = new StringReader(outputXml))
+            {
+                var unserializedApdu = (CommandAPDU)XmlSerializer.Deserialize(textReader);
+                Assert.AreEqual(commandApdu, unserializedApdu);
+            }   
             
             // Test automatic conversion to extended
             commandApdu.Lc = 0xF00D;
@@ -141,11 +220,27 @@ namespace WSCT_Unit_Tests.ISO7816
             Assert.IsFalse(commandApdu.IsCc2E);
             Assert.IsTrue(commandApdu.IsCc3E);
             Assert.IsFalse(commandApdu.IsCc4E);
+            Assert.IsTrue(commandApdu.IsExtended);
             
             // Test encoding
             Assert.AreEqual(Case3EApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x00, commandApdu.Ne);
             Assert.AreEqual(0x03, commandApdu.Nc);
+            
+            // Test XML serialization
+            var memoryStream = new MemoryStream();
+            TextWriter writer = new StreamWriter(memoryStream);
+            XmlSerializer.Serialize(writer, commandApdu);
+            writer.Flush();
+            var outputXml = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.AreEqual(Case3EXml, outputXml);
+            
+            // Test XML deserialization
+            using (TextReader textReader = new StringReader(outputXml))
+            {
+                var unserializedApdu = (CommandAPDU)XmlSerializer.Deserialize(textReader);
+                Assert.AreEqual(commandApdu, unserializedApdu);
+            }  
         }
         
         [Test(Description = "Case 4 C-APDU")]
@@ -161,11 +256,27 @@ namespace WSCT_Unit_Tests.ISO7816
             Assert.IsFalse(commandApdu.IsCc2E);
             Assert.IsFalse(commandApdu.IsCc3E);
             Assert.IsFalse(commandApdu.IsCc4E);
-            
+            Assert.IsFalse(commandApdu.IsExtended);
+
             // Test encoding
             Assert.AreEqual(Case4ApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x01, commandApdu.Ne);
             Assert.AreEqual(0x01, commandApdu.Nc);
+            
+            // Test XML serialization
+            var memoryStream = new MemoryStream();
+            TextWriter writer = new StreamWriter(memoryStream);
+            XmlSerializer.Serialize(writer, commandApdu);
+            writer.Flush();
+            var outputXml = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.AreEqual(Case4Xml, outputXml);
+            
+            // Test XML deserialization
+            using (TextReader textReader = new StringReader(outputXml))
+            {
+                var unserializedApdu = (CommandAPDU)XmlSerializer.Deserialize(textReader);
+                Assert.AreEqual(commandApdu, unserializedApdu);
+            }  
             
             // Test automatic conversion to extended
             commandApdu.Lc = 0xF00D;
@@ -188,11 +299,27 @@ namespace WSCT_Unit_Tests.ISO7816
             Assert.IsFalse(commandApdu.IsCc2E);
             Assert.IsFalse(commandApdu.IsCc3E);
             Assert.IsTrue(commandApdu.IsCc4E);
+            Assert.IsTrue(commandApdu.IsExtended);
             
             // Test encoding
             Assert.AreEqual(Case4EApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x02, commandApdu.Ne);
             Assert.AreEqual(0x03, commandApdu.Nc);
+            
+            // Test XML serialization
+            var memoryStream = new MemoryStream();
+            TextWriter writer = new StreamWriter(memoryStream);
+            XmlSerializer.Serialize(writer, commandApdu);
+            writer.Flush();
+            var outputXml = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.AreEqual(Case4EXml, outputXml);
+            
+            // Test XML deserialization
+            using (TextReader textReader = new StringReader(outputXml))
+            {
+                var unserializedApdu = (CommandAPDU)XmlSerializer.Deserialize(textReader);
+                Assert.AreEqual(commandApdu, unserializedApdu);
+            }  
         }
     }
 }

--- a/WSCT Unit Tests/ISO7816/CommandAPDUUnitTest.cs
+++ b/WSCT Unit Tests/ISO7816/CommandAPDUUnitTest.cs
@@ -1,0 +1,142 @@
+using NUnit.Framework;
+using WSCT.ISO7816;
+
+namespace WSCT_Unit_Tests.ISO7816
+{
+    [TestFixture]
+    public class CommandCaseUnitTest
+    {
+        // Case 1
+        private const string Case1Apdu = "00A4 0400";
+        private static readonly byte[] Case1ApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00 };
+
+        // Case 2
+        private const string Case2Apdu = "00A4 0400 F0";
+        private static readonly byte[] Case2ApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0xF0 };
+        
+        // Case 3
+        private const string Case3Apdu = "00A4 0400 04 0A0B0C0D";
+        private static readonly byte[] Case3ApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x04, 0x0A, 0x0B, 0x0C, 0x0D };
+
+        // Case 4
+        private const string Case4Apdu = "00A4 0400 04 0A0B0C0D F0";
+        private static readonly byte[] Case4ApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x04, 0x0A, 0x0B, 0x0C, 0x0D, 0xF0 };
+
+        // Case 2E
+        private const string Case2EApdu = "00A4 0400 00F00D";
+        private static readonly byte[] Case2EApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x00, 0xF0, 0x0D };
+        
+        // Case 3E
+        private const string Case3EApdu = "00A4 0400 000004 0A0B0C0D";
+        private static readonly byte[] Case3EApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x00, 0x00, 0x04, 0x0A, 0x0B, 0x0C, 0x0D };
+        
+        // Case 4E
+        private const string Case4EApdu = "00A4 0400 000004 0A0B0C0D F00D";
+        private static readonly byte[] Case4EApduByte = new byte[] { 0x00, 0xA4, 0x04, 0x00, 0x00, 0x00, 0x04, 0x0A, 0x0B, 0x0C, 0x0D, 0xF0, 0x0D };
+
+        [Test(Description = "Case 1 C-APDU")]
+        public void TestCase1ConstructorAndEncode()
+        {
+            // Test decoding
+            var commandApdu = new CommandAPDU(Case1Apdu);
+            Assert.AreEqual(CommandCase.CC1, commandApdu.CommandCase);
+            Assert.IsTrue(commandApdu.IsCc1);
+            Assert.IsFalse(commandApdu.IsCc2);
+            Assert.IsFalse(commandApdu.IsCc3);
+            Assert.IsFalse(commandApdu.IsCc4);
+            Assert.IsFalse(commandApdu.IsCc2E);
+            Assert.IsFalse(commandApdu.IsCc3E);
+            Assert.IsFalse(commandApdu.IsCc4E);
+            
+            // Test encoding
+            Assert.AreEqual(Case1ApduByte, commandApdu.BinaryCommand);
+            Assert.AreEqual(0x00, commandApdu.Ne);
+            Assert.AreEqual(0x00, commandApdu.Nc);
+        }
+        
+        [Test(Description = "Case 2 C-APDU")]
+        public void TestCase2ConstructorAndEncode()
+        {
+            // Test decoding
+            var commandApdu = new CommandAPDU(Case2Apdu);
+            Assert.AreEqual(CommandCase.CC2, commandApdu.CommandCase);
+            Assert.IsFalse(commandApdu.IsCc1);
+            Assert.IsTrue(commandApdu.IsCc2);
+            Assert.IsFalse(commandApdu.IsCc3);
+            Assert.IsFalse(commandApdu.IsCc4);
+            Assert.IsFalse(commandApdu.IsCc2E);
+            Assert.IsFalse(commandApdu.IsCc3E);
+            Assert.IsFalse(commandApdu.IsCc4E);
+            
+            // Test encoding
+            Assert.AreEqual(Case2ApduByte, commandApdu.BinaryCommand);
+            Assert.AreEqual(0x01, commandApdu.Ne);
+            Assert.AreEqual(0x00, commandApdu.Nc);
+        }
+        
+        [Test(Description = "Case 2 Extended C-APDU")]
+        public void TestCase2EConstructorAndEncode()
+        {
+            // Test decoding
+            var commandApdu = new CommandAPDU(Case2EApdu);
+            Assert.AreEqual(CommandCase.CC2E, commandApdu.CommandCase);
+            
+            // Test encoding
+            Assert.AreEqual(Case2EApduByte, commandApdu.BinaryCommand);
+            Assert.AreEqual(0x03, commandApdu.Ne);
+            Assert.AreEqual(0x00, commandApdu.Nc);
+        }
+        
+        [Test(Description = "Case 3 C-APDU")]
+        public void TestCase3ConstructorAndEncode()
+        {
+            // Test decoding
+            var commandApdu = new CommandAPDU(Case3Apdu);
+            Assert.AreEqual(CommandCase.CC3, commandApdu.CommandCase);
+            
+            // Test encoding
+            Assert.AreEqual(Case3ApduByte, commandApdu.BinaryCommand);
+            Assert.AreEqual(0x00, commandApdu.Ne);
+            Assert.AreEqual(0x01, commandApdu.Nc);
+        }
+        
+        [Test(Description = "Case 3 Extended C-APDU")]
+        public void TestCase3EConstructorAndEncode()
+        {
+            // Test decoding
+            var commandApdu = new CommandAPDU(Case3EApdu);
+            Assert.AreEqual(CommandCase.CC3E, commandApdu.CommandCase);
+            
+            // Test encoding
+            Assert.AreEqual(Case3EApduByte, commandApdu.BinaryCommand);
+            Assert.AreEqual(0x00, commandApdu.Ne);
+            Assert.AreEqual(0x03, commandApdu.Nc);
+        }
+        
+        [Test(Description = "Case 4 C-APDU")]
+        public void TestCase4ConstructorAndEncode()
+        {
+            // Test decoding
+            var commandApdu = new CommandAPDU(Case4Apdu);
+            Assert.AreEqual(CommandCase.CC4, commandApdu.CommandCase);
+            
+            // Test encoding
+            Assert.AreEqual(Case4ApduByte, commandApdu.BinaryCommand);
+            Assert.AreEqual(0x01, commandApdu.Ne);
+            Assert.AreEqual(0x01, commandApdu.Nc);
+        }
+        
+        [Test(Description = "Case 4 Extended C-APDU")]
+        public void TestCase4EConstructorAndEncode()
+        {
+            // Test decoding
+            var commandApdu = new CommandAPDU(Case4EApdu);
+            Assert.AreEqual(CommandCase.CC4E, commandApdu.CommandCase);
+            
+            // Test encoding
+            Assert.AreEqual(Case4EApduByte, commandApdu.BinaryCommand);
+            Assert.AreEqual(0x02, commandApdu.Ne);
+            Assert.AreEqual(0x03, commandApdu.Nc);
+        }
+    }
+}

--- a/WSCT Unit Tests/ISO7816/CommandAPDUUnitTest.cs
+++ b/WSCT Unit Tests/ISO7816/CommandAPDUUnitTest.cs
@@ -72,6 +72,13 @@ namespace WSCT_Unit_Tests.ISO7816
             Assert.AreEqual(Case2ApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x01, commandApdu.Ne);
             Assert.AreEqual(0x00, commandApdu.Nc);
+            
+            // Test automatic conversion to extended
+            commandApdu.Lc = 0xF00D;
+            Assert.AreEqual(CommandCase.CC2E, commandApdu.CommandCase);
+            commandApdu = new CommandAPDU(Case2Apdu);
+            commandApdu.Le = 0xF00D;
+            Assert.AreEqual(CommandCase.CC2E, commandApdu.CommandCase);
         }
         
         [Test(Description = "Case 2 Extended C-APDU")]
@@ -80,6 +87,13 @@ namespace WSCT_Unit_Tests.ISO7816
             // Test decoding
             var commandApdu = new CommandAPDU(Case2EApdu);
             Assert.AreEqual(CommandCase.CC2E, commandApdu.CommandCase);
+            Assert.IsFalse(commandApdu.IsCc1);
+            Assert.IsFalse(commandApdu.IsCc2);
+            Assert.IsFalse(commandApdu.IsCc3);
+            Assert.IsFalse(commandApdu.IsCc4);
+            Assert.IsTrue(commandApdu.IsCc2E);
+            Assert.IsFalse(commandApdu.IsCc3E);
+            Assert.IsFalse(commandApdu.IsCc4E);
             
             // Test encoding
             Assert.AreEqual(Case2EApduByte, commandApdu.BinaryCommand);
@@ -93,11 +107,25 @@ namespace WSCT_Unit_Tests.ISO7816
             // Test decoding
             var commandApdu = new CommandAPDU(Case3Apdu);
             Assert.AreEqual(CommandCase.CC3, commandApdu.CommandCase);
+            Assert.IsFalse(commandApdu.IsCc1);
+            Assert.IsFalse(commandApdu.IsCc2);
+            Assert.IsTrue(commandApdu.IsCc3);
+            Assert.IsFalse(commandApdu.IsCc4);
+            Assert.IsFalse(commandApdu.IsCc2E);
+            Assert.IsFalse(commandApdu.IsCc3E);
+            Assert.IsFalse(commandApdu.IsCc4E);
             
             // Test encoding
             Assert.AreEqual(Case3ApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x00, commandApdu.Ne);
             Assert.AreEqual(0x01, commandApdu.Nc);
+            
+            // Test automatic conversion to extended
+            commandApdu.Lc = 0xF00D;
+            Assert.AreEqual(CommandCase.CC3E, commandApdu.CommandCase);
+            commandApdu = new CommandAPDU(Case3Apdu);
+            commandApdu.Le = 0xF00D;
+            Assert.AreEqual(CommandCase.CC3E, commandApdu.CommandCase);
         }
         
         [Test(Description = "Case 3 Extended C-APDU")]
@@ -106,6 +134,13 @@ namespace WSCT_Unit_Tests.ISO7816
             // Test decoding
             var commandApdu = new CommandAPDU(Case3EApdu);
             Assert.AreEqual(CommandCase.CC3E, commandApdu.CommandCase);
+            Assert.IsFalse(commandApdu.IsCc1);
+            Assert.IsFalse(commandApdu.IsCc2);
+            Assert.IsFalse(commandApdu.IsCc3);
+            Assert.IsFalse(commandApdu.IsCc4);
+            Assert.IsFalse(commandApdu.IsCc2E);
+            Assert.IsTrue(commandApdu.IsCc3E);
+            Assert.IsFalse(commandApdu.IsCc4E);
             
             // Test encoding
             Assert.AreEqual(Case3EApduByte, commandApdu.BinaryCommand);
@@ -119,11 +154,25 @@ namespace WSCT_Unit_Tests.ISO7816
             // Test decoding
             var commandApdu = new CommandAPDU(Case4Apdu);
             Assert.AreEqual(CommandCase.CC4, commandApdu.CommandCase);
+            Assert.IsFalse(commandApdu.IsCc1);
+            Assert.IsFalse(commandApdu.IsCc2);
+            Assert.IsFalse(commandApdu.IsCc3);
+            Assert.IsTrue(commandApdu.IsCc4);
+            Assert.IsFalse(commandApdu.IsCc2E);
+            Assert.IsFalse(commandApdu.IsCc3E);
+            Assert.IsFalse(commandApdu.IsCc4E);
             
             // Test encoding
             Assert.AreEqual(Case4ApduByte, commandApdu.BinaryCommand);
             Assert.AreEqual(0x01, commandApdu.Ne);
             Assert.AreEqual(0x01, commandApdu.Nc);
+            
+            // Test automatic conversion to extended
+            commandApdu.Lc = 0xF00D;
+            Assert.AreEqual(CommandCase.CC4E, commandApdu.CommandCase);
+            commandApdu = new CommandAPDU(Case4Apdu);
+            commandApdu.Le = 0xF00D;
+            Assert.AreEqual(CommandCase.CC4E, commandApdu.CommandCase);
         }
         
         [Test(Description = "Case 4 Extended C-APDU")]
@@ -132,6 +181,13 @@ namespace WSCT_Unit_Tests.ISO7816
             // Test decoding
             var commandApdu = new CommandAPDU(Case4EApdu);
             Assert.AreEqual(CommandCase.CC4E, commandApdu.CommandCase);
+            Assert.IsFalse(commandApdu.IsCc1);
+            Assert.IsFalse(commandApdu.IsCc2);
+            Assert.IsFalse(commandApdu.IsCc3);
+            Assert.IsFalse(commandApdu.IsCc4);
+            Assert.IsFalse(commandApdu.IsCc2E);
+            Assert.IsFalse(commandApdu.IsCc3E);
+            Assert.IsTrue(commandApdu.IsCc4E);
             
             // Test encoding
             Assert.AreEqual(Case4EApduByte, commandApdu.BinaryCommand);

--- a/WSCT/ISO7816/CommandAPDU.cs
+++ b/WSCT/ISO7816/CommandAPDU.cs
@@ -25,6 +25,7 @@ namespace WSCT.ISO7816
 
         private UInt32 _lc;
         private UInt32 _le;
+
         private byte[] _udc;
 
         #endregion
@@ -48,14 +49,17 @@ namespace WSCT.ISO7816
                         _hasLe = false;
                         break;
                     case CommandCase.CC2:
+                    case CommandCase.CC2E:
                         _hasLc = false;
                         _hasLe = true;
                         break;
                     case CommandCase.CC3:
+                    case CommandCase.CC3E:
                         _hasLc = true;
                         _hasLe = false;
                         break;
                     case CommandCase.CC4:
+                    case CommandCase.CC4E:
                         _hasLc = true;
                         _hasLe = true;
                         break;
@@ -106,6 +110,77 @@ namespace WSCT.ISO7816
             {
                 _lc = value;
                 HasLc = true;
+            }
+        }
+
+        /// <summary>
+        /// Accessor to the Ne value of the C-APDU.
+        /// Valid values: 0, 1, 2, or 3
+        /// </summary>
+        public UInt32 Ne
+        {
+            get
+            {
+                switch (_commandCase)
+                {
+                    // Case 1 and 3 do not have expected response length
+                    case CommandCase.CC1:
+                    case CommandCase.CC3:
+                    case CommandCase.CC3E:
+                        return 0;
+                    
+                    // Case 2 and 4 are standard commands with short (1-byte) expected response lengths
+                    case CommandCase.CC2:
+                    case CommandCase.CC4:
+                        return 1;
+                    
+                    // The expected response length is 3 bytes (0x00, 0xXX, 0XX) when command length Lc is absent
+                    case CommandCase.CC2E:
+                        return 3;
+                    
+                    // When command length Lc is present (and extended), expected response length is encoded as to bytes
+                    case CommandCase.CC4E:
+                        return 2;
+
+                    // If the command case is unknown, the length is unknown.
+                    case CommandCase.Unknown:
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Accessor to the Nc value of the C-APDU.
+        /// Valid values: 0, 1, or 3
+        /// </summary>
+        public UInt32 Nc
+        {
+            get
+            {
+                switch (_commandCase)
+                {
+                    // Case 1 and 2 do not have command data
+                    case CommandCase.CC1:
+                    case CommandCase.CC2:
+                    case CommandCase.CC2E:
+                        return 0;
+                    
+                    // Case 3 and 4 are standard commands with short (1-byte) command data
+                    case CommandCase.CC3:
+                    case CommandCase.CC4:
+                        return 1;
+                    
+                    // Extended-length commands with response lengths are encoded as three bytes (0x00, 0xXX, 0xXX)
+                    case CommandCase.CC3E:
+                    case CommandCase.CC4E:
+                        return 3;
+
+                    // If the command case is unknown, the length is unknown.
+                    case CommandCase.Unknown:
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
             }
         }
 
@@ -212,6 +287,14 @@ namespace WSCT.ISO7816
         {
             get { return _commandCase == CommandCase.CC2; }
         }
+        
+        /// <summary>
+        /// Informs if the C-APDU is a Extended Command Case 2.
+        /// </summary>
+        public Boolean IsCc2E
+        {
+            get { return _commandCase == CommandCase.CC2E; }
+        }
 
         /// <summary>
         /// Informs if the C-APDU is a Command Case 3.
@@ -219,6 +302,14 @@ namespace WSCT.ISO7816
         public Boolean IsCc3
         {
             get { return _commandCase == CommandCase.CC3; }
+        }
+        
+        /// <summary>
+        /// Informs if the C-APDU is a Extended Command Case 3.
+        /// </summary>
+        public Boolean IsCc3E
+        {
+            get { return _commandCase == CommandCase.CC3E; }
         }
 
         /// <summary>
@@ -228,6 +319,14 @@ namespace WSCT.ISO7816
         {
             get { return _commandCase == CommandCase.CC4; }
         }
+        
+        /// <summary>
+        /// Informs if the C-APDU is a Extended Command Case 4.
+        /// </summary>
+        public Boolean IsCc4E
+        {
+            get { return _commandCase == CommandCase.CC4E; }
+        }
 
         /// <summary>
         /// Accessor to the entire C-APDU in byte array format.
@@ -236,27 +335,52 @@ namespace WSCT.ISO7816
         {
             get
             {
-                var length = 4 + (HasLc ? Udc.Length + 1 : 0) + (HasLe ? 1 : 0);
-                var data = new byte[length];
-                data[0] = Cla;
-                data[1] = Ins;
-                data[2] = P1;
-                data[3] = P2;
+                // All APDUs have a length of at least 4: [CLA] [INS] [P1] [P2]
+                var length = 4;
+
+                // If command data is present, allocate space for the data and the length
                 if (HasLc)
                 {
-                    data[4] = (byte)Lc;
-                    Array.Copy(Udc, 0, data, 5, Udc.Length);
-                    if (HasLe)
-                    {
-                        data[5 + Udc.Length] = (byte)Le;
-                    }
+                    length += Udc.Length + (int)Nc;
                 }
-                else
+
+                // If expected length is present, allocate space for it as well
+                if (HasLe)
                 {
-                    if (HasLe)
-                    {
-                        data[4] = (byte)Le;
-                    }
+                    length += (int)Ne;
+                }
+
+                // Write out the binary data
+                var data = new byte[length];
+                var offset = 0;
+                data[offset++] = Cla;
+                data[offset++] = Ins;
+                data[offset++] = P1;
+                data[offset++] = P2;
+                
+                // Handle Lc
+                if (HasLc)
+                {
+                    // The bit converter produces a bit array of 4 bytes, so we can keep the last X bytes
+                    var lcBytes = BitConverter.GetBytes(Lc);
+                    if (BitConverter.IsLittleEndian)
+                        Array.Reverse(lcBytes);
+                    var lcOffset = lcBytes.Length - (int)Nc;
+                    Array.Copy(lcBytes, lcOffset, data, offset, lcBytes.Length - lcOffset);
+                    offset += (int)Nc;
+                    
+                    Array.Copy(Udc, 0, data, offset, Udc.Length);
+                    offset += Udc.Length;
+                }
+
+                // Handle Le
+                if (HasLe)
+                {
+                    var leBytes = BitConverter.GetBytes(Le);
+                    if (BitConverter.IsLittleEndian)
+                        Array.Reverse(leBytes);
+                    var leOffset = leBytes.Length - (int)Ne;
+                    Array.Copy(leBytes, leOffset, data, offset, leBytes.Length - leOffset);
                 }
                 return data;
             }
@@ -420,7 +544,7 @@ namespace WSCT.ISO7816
 
         #endregion
 
-        #region >> ICardCommand Membres
+        #region >> ICardCommand Members
 
         /// <inheritdoc />
         public ICardCommand Parse(byte[] cAPDU)
@@ -429,36 +553,77 @@ namespace WSCT.ISO7816
             {
                 throw new Exception("cApdu.Length<4");
             }
-            Cla = cAPDU[0];
-            Ins = cAPDU[1];
-            P1 = cAPDU[2];
-            P2 = cAPDU[3];
-            CommandCase = CommandCase.CC1;
 
-            UInt32 pos = 4;
-            if (cAPDU.Length > pos)
+            var offset = 0;
+            byte[] udcBytes;
+
+            Cla = cAPDU[offset++];
+            Ins = cAPDU[offset++];
+            P1 = cAPDU[offset++];
+            P2 = cAPDU[offset++];
+            CommandCase = CommandCase.CC1;
+            
+            // Is additional data present?
+            if (cAPDU.Length <= offset) return this;
+            
+            // Parse the length
+            var lengthByte = cAPDU[offset++];
+            if (cAPDU.Length == offset)
             {
-                UInt32 length = cAPDU[pos];
-                pos += 1;
-                if (cAPDU.Length >= pos + length)
+                // Case 2, one byte length
+                CommandCase = CommandCase.CC2;
+                Le = lengthByte;
+                return this;
+            }
+            else if (lengthByte == 0 && cAPDU.Length == offset + 2)
+            {
+                // Case 2, 3 byte Lc
+                CommandCase = CommandCase.CC2E;
+                var firstByte = (int)cAPDU[offset++];
+                var secondByte = (int)cAPDU[offset++];
+                Le = Convert.ToUInt32((firstByte * 256) + secondByte);
+                return this;
+            }
+
+            // Single-byte Lc
+            if (lengthByte > 0)
+            {
+                if (cAPDU.Length == offset + lengthByte)
                 {
-                    Lc = length;
-                    Udc = new byte[length];
-                    Array.Copy(cAPDU, (int)pos, Udc, 0, (int)length);
-                    pos += length;
                     CommandCase = CommandCase.CC3;
-                    if (cAPDU.Length > pos)
-                    {
-                        Le = cAPDU[pos];
-                        CommandCase = CommandCase.CC4;
-                    }
                 }
                 else
                 {
-                    CommandCase = CommandCase.CC2;
-                    Le = length;
+                    CommandCase = CommandCase.CC4;
+                    Le = cAPDU[offset + lengthByte];
+                }
+                udcBytes = new byte[lengthByte];
+                Array.Copy(cAPDU, offset, udcBytes, 0, lengthByte);
+                Udc = udcBytes;
+            }
+            else
+            {
+                // Multi-byte Lc
+                int firstByte = cAPDU[offset++];
+                int secondByte = cAPDU[offset++];
+                Lc = Convert.ToUInt32((firstByte * 256) + secondByte);
+                udcBytes = new byte[Lc];
+                Array.Copy(cAPDU, offset, udcBytes, 0, Lc);
+                Udc = udcBytes;
+                
+                if (cAPDU.Length == offset + Lc)
+                {
+                    CommandCase = CommandCase.CC3E;
+                }
+                else
+                {
+                    CommandCase = CommandCase.CC4E;
+                    firstByte = cAPDU[offset + Lc];
+                    secondByte = cAPDU[offset + Lc + 1];
+                    Le = Convert.ToUInt32((firstByte * 256) + secondByte);
                 }
             }
+
             return this;
         }
 

--- a/WSCT/ISO7816/CommandAPDU.cs
+++ b/WSCT/ISO7816/CommandAPDU.cs
@@ -95,6 +95,27 @@ namespace WSCT.ISO7816
             get { return _le; }
             set
             {
+                if (value > 0xFFFF)
+                {
+                    throw new Exception("Le exceeds maximum size.");
+                } else if (value > 0xFF)
+                {
+                    // Convert to extended case if required
+                    switch (CommandCase)
+                    {
+                        case CommandCase.CC2:
+                            CommandCase = CommandCase.CC2E;
+                            break;
+                        case CommandCase.CC3:
+                            CommandCase = CommandCase.CC3E;
+                            break;
+                        case CommandCase.CC4:
+                            CommandCase = CommandCase.CC4E;
+                            break;
+                        default:
+                            break;
+                    }
+                }
                 _le = value;
                 HasLe = true;
             }
@@ -108,6 +129,27 @@ namespace WSCT.ISO7816
             get { return _lc; }
             set
             {
+                if (value > 0xFFFF)
+                {
+                    throw new Exception("Lc exceeds maximum size.");
+                } else if (value > 0xFF)
+                {
+                    // Convert to extended case if required
+                    switch (CommandCase)
+                    {
+                        case CommandCase.CC2:
+                            CommandCase = CommandCase.CC2E;
+                            break;
+                        case CommandCase.CC3:
+                            CommandCase = CommandCase.CC3E;
+                            break;
+                        case CommandCase.CC4:
+                            CommandCase = CommandCase.CC4E;
+                            break;
+                        default:
+                            break;
+                    }
+                }
                 _lc = value;
                 HasLc = true;
             }

--- a/WSCT/ISO7816/CommandCase.cs
+++ b/WSCT/ISO7816/CommandCase.cs
@@ -28,6 +28,21 @@
         /// <summary>
         /// Command case 4: (Lc UDC) and Le found in C-APDU, UDR found in R-APDU.
         /// </summary>
-        CC4 = 4
+        CC4 = 4,
+        
+        /// <summary>
+        /// Command Case 2 Extended: no (Lc UDC) in C-APDU, Le found in C-APDU, UDR found in R-APDU.
+        /// </summary>
+        CC2E = 5,
+        
+        /// <summary>
+        /// Command case 3 extended: no Le in C-APDU, (Lc UDC) found in  C-APDU, no UDR in R-APDU.
+        /// </summary>
+        CC3E = 6,
+        
+        /// <summary>
+        /// Command case 4 extended: (Lc UDC) and Le found in C-APDU, UDR found in R-APDU.
+        /// </summary>        
+        CC4E = 7
     }
 }


### PR DESCRIPTION
As described in #4 ,  extended length APDUs are not currently supported.

This patch adds support for Ne and Nr, allows multi-byte encoding, automatically switches when lengths > 255 are set or detected, and adds testing to help avoid any breaking changes.